### PR TITLE
Fix performance issue under Ruby 1.9 by using fixed methods instead of method_missing

### DIFF
--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -291,11 +291,12 @@ module Commander
     # Implements ask_for_CLASS methods.
     
     module AskForClass
-      # All special cases in HighLine::Question#convert
+      # All special cases in HighLine::Question#convert, except those that implement #parse
+      ([Float, Integer, String, Symbol, Regexp, Array, File, Pathname] +
       # All Classes that respond to #parse
-      ([Float, Integer, String, Symbol, Regexp, Array, File, Pathname] + # Date, DateTime
       Object.constants.map do |const|
-        Module.const_get(const)
+        # const_get(:Config) issues a deprecation warning on ruby 1.8.7
+        Object.const_get(const) unless const == :Config
       end.select do |const|
         const.is_a? Class and const.respond_to? :parse
       end).each do |klass|


### PR DESCRIPTION
My commander application suffers significant delays while loading under ruby 1.9.

I have reduced the problem to the following test case:

``` ruby
require 'commander/import'
program :version, '0.0.1'
program :description, 'Test case of commander load speed'
require 'active_record'
```

Execution time increases significantly in ruby 1.9 (0.3 seconds vs 1.7 seconds):

```
$ rvm use 1.8.7
$ time ruby test --help > /dev/null

real    0m0.343s
user    0m0.310s
sys 0m0.030s

$ rvm use 1.9.2
$ time ruby test --help > /dev/null

real    0m1.761s
user    0m1.670s
sys 0m0.080s
```

It appears that Commander::UI::AskForClass#method_missing interacts badly with Kernel#require as used by ActiveRecord. The interaction occurs because "commander/import" includes the AskForClass module directly into Kernel.

I have a fix which replaces the method_missing implementation with a fixed number of defined methods for each class that needs an ask_for_\* method. Initially it only implements ask_for_array, but it should be easy to extend if required.

The fix appears to mitigate the performance problem:

```
$ gem install ../commander-4.0.5-fixed.gem --local
$ time ruby test --help > /dev/null

real    0m0.568s
user    0m0.500s
sys 0m0.060s
```
