### PR TITLE
Allow gem building on ruby 1.9 by using Psych instead of Syck for YAML

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 $:.unshift 'lib'
 
+require 'psych'
 require 'rubygems'
 
 load_errors = ['highline', 'echoe'].map do |g|


### PR DESCRIPTION
As noted in DEVELOPMENT, building the gem on ruby 1.9 doesn't work:

```
$ rake gem
Gemspec generated
WARNING:  description and summary are identical
rake aborted!
undefined method `write' for #<Syck::Emitter:0x0000000316a3c0>
```

This patch fixes it for me.
