### PR TITLE
Make commander work on Windows by making Commander::UI.enable_paging a NOOP

### DIFF
--- a/lib/commander/platform.rb
+++ b/lib/commander/platform.rb
@@ -1,8 +1,13 @@
+require 'rbconfig'
 
 module Commander
   module Platform
     def self.jruby?
       defined?(RUBY_ENGINE) && (RUBY_ENGINE == 'jruby')
+    end
+
+    def self.win?
+      RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
     end
   end
 end

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -252,7 +252,7 @@ module Commander
     
     def enable_paging
       return unless $stdout.tty?
-      return if Platform::jruby? # Fork is not supported by JRuby
+      return if Platform::jruby? || Platform::win? # Fork is neither supported by JRuby nor Windows
       read, write = IO.pipe
 
       if Kernel.fork


### PR DESCRIPTION
One of our Windows users encountered a problem with a commander based gem that is similar to issue #21.

This change turns enable_paging into a NOOP on Windows platforms.
