### PR TITLE
Upgrade highline dependency to the current version.

### DIFF
--- a/commander.gemspec
+++ b/commander.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency("highline", "~> 1.5.0")
+  s.add_runtime_dependency("highline", "~> 1.6.11")
+  
   s.add_development_dependency("rspec", "~> 2")
   s.add_development_dependency("rake")
   s.add_development_dependency("simplecov")


### PR DESCRIPTION
Hi there,

First of all, thanks for this awesome gem.

Is it ok if we upgrade the highline dependency to the current version or maybe to '~> 1.6.0' ? Specs run through with no failure.

Thanks for all your work!

Maik
