### PR TITLE
fixed valid_command_names_from to match exact commands only

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -223,7 +223,7 @@ module Commander
     
     def valid_command_names_from *args
       arg_string = args.delete_if { |value| value =~ /^-/ }.join ' '
-      commands.keys.find_all { |name| name if /^#{name}/.match arg_string }
+      commands.keys.find_all { |name| name if /^#{name}\b/.match arg_string }
     end
     
     ##

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -361,6 +361,11 @@ describe Commander do
     it "should return empty array when no possible command names exist" do
       command_runner.valid_command_names_from('fake', 'command', 'name').should eq([])
     end
+
+    it "should match exact commands only" do
+      command('foo') {}
+      command_runner.valid_command_names_from('foobar').should eq([])
+    end
   end
   
   describe "#command_name_from_args" do


### PR DESCRIPTION
i noticed that command "foo" with arguments foobar, invokes foo and keeps foobar in args array. I think this is a bug and i fixed it.
