### PR TITLE
Remove require '<machine name>' and set default version to '0.0.1'

### DIFF
--- a/bin/commander
+++ b/bin/commander
@@ -25,9 +25,8 @@ command :init do |c|
           
           require 'rubygems'
           require 'commander/import'
-          require '#{name}'
           
-          program :version, #{name.capitalize}::VERSION
+          program :version, '0.0.1'
           program :description, '#{description}'
            
         ...


### PR DESCRIPTION
Fixes most of #42

Removing the name prompt is less straightforward and I'll do that later.
