### PR TITLE
Replace eval

### DIFF
--- a/lib/commander/core_ext/array.rb
+++ b/lib/commander/core_ext/array.rb
@@ -18,7 +18,7 @@ class Array
   #
   
   def self.parse string
-    string.split ' '
+    string.split(/(?<!\\)\s/).map { |s| s.gsub('\\ ', ' ') }
   end
     
 end


### PR DESCRIPTION
Hi, guys
I've replaced eval with split, because of errors like that:

```
/Users/max/.rvm/gems/ruby-1.9.3-p194@pas/gems/commander-4.1.2/lib/commander/core_ext/array.rb:22:in `eval': (eval):1: syntax error, unexpected tIDENTIFIER, expecting $end (SyntaxError)
%w(test))
                                              ^
    from /Users/max/.rvm/gems/ruby-1.9.3-p194@pas/gems/commander-4.1.2/lib/commander/core_ext/array.rb:22:in `parse'
    from /Users/max/.rvm/gems/ruby-1.9.3-p194@pas/gems/highline-1.6.12/lib/highline/question.rb:329:in `convert'
```
