### PR TITLE
Added a way to set speaking rate in speech method

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -159,6 +159,7 @@ following methods to simplify common tasks:
   speak 'What is your favorite food? '
   food = ask 'favorite food?: '
   speak "Wow, I like #{food} too. We have so much in common." 
+  speak "I like #{food} aswell!", "Victoria", 190
 
   # Execute arbitrary applescript
   applescript 'foo'

--- a/README.rdoc
+++ b/README.rdoc
@@ -159,7 +159,7 @@ following methods to simplify common tasks:
   speak 'What is your favorite food? '
   food = ask 'favorite food?: '
   speak "Wow, I like #{food} too. We have so much in common." 
-  speak "I like #{food} aswell!", "Victoria", 190
+  speak "I like #{food} as well!", "Victoria", 190
 
   # Execute arbitrary applescript
   applescript 'foo'

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -129,7 +129,7 @@ module Commander
     #   speak 'What is your favorite food? '
     #   food = ask 'favorite food?: '
     #   speak "Wow, I like #{food} too. We have so much in common." 
-    #   speak "I like #{food} aswell!", "Victoria", 190
+    #   speak "I like #{food} as well!", "Victoria", 190
     #
     # === Notes
     #

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -119,22 +119,25 @@ module Commander
     end
 
     ##
-    # Speak _message_ using _voice_ which defaults
-    # to 'Alex', which is one of the better voices.
+    # Speak _message_ using _voice_ at a speaking rate of _rate_
+    # 
+    # Voice defaults to 'Alex', which is one of the better voices.
+    # Speaking rate defaults to 175 words per minute
     #
     # === Examples
     #    
     #   speak 'What is your favorite food? '
     #   food = ask 'favorite food?: '
-    #   speak "wow, I like #{food} too. We have so much alike." 
+    #   speak "Wow, I like #{food} too. We have so much in common." 
+    #   speak "I like #{food} aswell!", "Victoria", 190
     #
     # === Notes
     #
     # * MacOS only
     #
     
-    def speak message, voice = :Alex
-      Thread.new { applescript "say #{message.inspect} using #{voice.to_s.inspect}" }
+    def speak message, voice = :Alex, rate = 175
+      Thread.new { applescript "say #{message.inspect} using #{voice.to_s.inspect} speaking rate #{rate}" }
     end
     
     ##

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.1.3'
+  VERSION = '4.1.5'
 end

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.1.5'
+  VERSION = '4.1.4'
 end


### PR DESCRIPTION
# Overview

Adds a way to set the speaking rate (wpm) in the speech method without having to manually use the applescript method
# Examples

``` ruby
speak "HELLO!", "Alex", 250 # Says "HELLO!" with voice "Alex" at a speaking rate of 250 wpm
```

``` ruby
speak "HELLO!" # Says "HELLO!" with voice "Alex" at a default speaking rate of 175 wpm
```
# Changes
- [x] Added speech rate parameter to method speech
- [x] Updated documentation to reflect changes
- [x] Bumped version to 4.1.4 (from 4.1.3)
