### PR TITLE
respect the user's values for $LESS, if already set

### DIFF
--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -284,7 +284,7 @@ module Commander
         $stdin.reopen read
         write.close; read.close
         Kernel.select [$stdin]
-        ENV['LESS'] = 'FSRX'
+        ENV['LESS'] = 'FSRX' unless ENV.key? 'LESS'
         pager = ENV['PAGER'] || 'less'
         exec pager rescue exec '/bin/sh', '-c', pager
       else


### PR DESCRIPTION
commander overrides any values the user may have already set for their `LESS` environment variable, and doesn't provide a way to configure what the override values will be.

this pull request changes the behavior from overriding to defaulting, so the user or host program has a chance to configure the pager behavior.
