### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [<img src="https://secure.travis-ci.org/ggilder/commander.png?branch=master" alt="Build Status" />](http://travis-ci.org/ggilder/commander)
+[![Inline docs](http://inch-pages.github.io/github/visionmedia/commander.png)](http://inch-pages.github.io/github/visionmedia/commander)
 
 # Commander
 


### PR DESCRIPTION
Hi TJ,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/visionmedia/commander.png)](http://inch-pages.github.io/github/visionmedia/commander) (and hopefully inspire them to write inline-docs as good as these)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Commander is http://inch-pages.github.io/github/visionmedia/commander/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
