### PR TITLE
commands -> defined_commands to fix pry conflict

### DIFF
--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -1,14 +1,25 @@
-
 module Commander
   module Delegates
-    %w( add_command command program run! global_option
-        commands alias_command default_command
-        always_trace! never_trace! ).each do |meth|
+    %w(
+      add_command
+      command
+      program
+      run!
+      global_option
+      alias_command
+      default_command
+      always_trace!
+      never_trace!
+    ).each do |meth|
       eval <<-END, binding, __FILE__, __LINE__
         def #{meth} *args, &block
           ::Commander::Runner.instance.#{meth} *args, &block
         end
       END
+    end
+
+    def defined_commands(*args, &block)
+      ::Commander::Runner.instance.commands(*args, &block)
     end
   end
 end


### PR DESCRIPTION
Rename `commands` method, which I'm guessing is very infrequently used,
to avoid a conflict with pry. According to
https://github.com/pry/pry/issues/1344 this will also be fixed in pry
soon; but this seems like a fine interim measure.

cc @KrauseFx @toobulkeh @ralfclaassens