### PR TITLE
issue #81 - add after_global_options hook command

### DIFF
--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -3,6 +3,7 @@ module Commander
     %w(
       add_command
       command
+      after_global_options
       program
       run!
       global_option


### PR DESCRIPTION
I just tested it wokring like:

```
...
      after_global_options do |c|
        c.action do |args, options|
          require 'pry'
          binding.pry
        end
      end

      run!
...
```

I didn't write any doc as I've no idea if you like the implementation. So let me know.
update: now I think more about it, perhaps it will be better to just specify the block like:

```
 after_global_options do |options|
  # init code
end
```

Would be simpler and more straightforward. If you confirm. I'll update PR.
